### PR TITLE
since 0.5.3 Nocrypto.Uncommon.Cs.concat is gone, but cstruc…

### DIFF
--- a/lib/rfc6287.ml
+++ b/lib/rfc6287.ml
@@ -213,7 +213,7 @@ let format_data_input (di, ss) c q p s t =
     | None -> None
     | Some _ ->
       Some (List.fold_left (fun a y -> a + (len y)) 0 [fss;fc;fq;fp;fs]) in
-  Uncommon.Cs.concat [fss;fc;fq;fp;fs;ft], (c_off, t_off)
+  Cstruct.concat [fss;fc;fq;fp;fs;ft], (c_off, t_off)
 
 let gen1 ~c ~p ~s ~t ~key ~q suite =
   try

--- a/opam
+++ b/opam
@@ -18,6 +18,7 @@ remove:  [ "ocamlfind" "remove" "rfc6287" ]
 depends: [
   "ocamlfind" {build}
   "nocrypto" {>= "0.5.1"}
+  "cstruct" {>= "1.7.0"}
   "astring"
   "hex"
   "rresult"


### PR DESCRIPTION
…t (>=1.7.0) provides a concat these days

I suspect in the main opam repository someone should constrain the `nocrypto` dependency of released `rfc6287` versions (and maybe make a new release which works with more current nocrypto).

(found via @avsm CI infrastructure https://ci.ocaml.io/log/saved/docker-run-57721310f236e6b721e13161444f42cd/536eef3fe2f442d00fd0c0f34979729a4602914a)